### PR TITLE
Add Next.js example with shadcn button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # beasy-experiments
+
+This repository contains a basic Next.js example using the [shadcn/ui](https://www.npmjs.com/package/shadcn) component library. The example lives in `next-app/`.
+
+Run the development server with `npm run dev` inside the `next-app` folder.

--- a/next-app/app/globals.css
+++ b/next-app/app/globals.css
@@ -1,0 +1,16 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --background: 0 0% 100%;
+  --foreground: 0 0% 3.9%;
+  --primary: 220 68% 50%;
+  --primary-foreground: 0 0% 100%;
+  --radius: 1rem;
+}
+
+body {
+  background-color: hsl(var(--background));
+  color: hsl(var(--foreground));
+}

--- a/next-app/app/layout.tsx
+++ b/next-app/app/layout.tsx
@@ -1,0 +1,10 @@
+import './globals.css'
+import { ReactNode } from 'react'
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/next-app/app/page.tsx
+++ b/next-app/app/page.tsx
@@ -1,0 +1,9 @@
+import { Button } from '../components/ui/button'
+
+export default function Home() {
+  return (
+    <main className="flex min-h-screen items-center justify-center">
+      <Button className="px-4 py-2">Click Me</Button>
+    </main>
+  )
+}

--- a/next-app/components/ui/button.tsx
+++ b/next-app/components/ui/button.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react'
+import { VariantProps, cva } from 'class-variance-authority'
+import { cn } from '../../lib/utils'
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center rounded-lg text-sm font-medium transition-colors focus:outline-none disabled:opacity-50 disabled:pointer-events-none',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        outline: 'border border-input hover:bg-accent hover:text-accent-foreground',
+      },
+      size: {
+        default: 'h-10 py-2 px-4',
+        sm: 'h-9 px-3 rounded-md',
+        lg: 'h-11 px-8 rounded-md',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  }
+)
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, ...props }, ref) => {
+    return (
+      <button className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />
+    )
+  }
+)
+Button.displayName = 'Button'
+
+export { Button, buttonVariants }

--- a/next-app/lib/utils.ts
+++ b/next-app/lib/utils.ts
@@ -1,0 +1,7 @@
+import { ClassValue } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+import clsx from 'clsx'
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/next-app/next-env.d.ts
+++ b/next-app/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next-app/next.config.mjs
+++ b/next-app/next.config.mjs
@@ -1,0 +1,5 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+}
+export default nextConfig

--- a/next-app/package.json
+++ b/next-app/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "next-app",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "clsx": "1.2.1",
+    "tailwind-merge": "2.2.1",
+    "class-variance-authority": "0.6.1"
+  }
+}

--- a/next-app/postcss.config.js
+++ b/next-app/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/next-app/tailwind.config.cjs
+++ b/next-app/tailwind.config.cjs
@@ -1,0 +1,24 @@
+module.exports = {
+  content: [
+    './app/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}',
+  ],
+  darkMode: ['class'],
+  theme: {
+    container: { center: true },
+    extend: {
+      colors: {
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))',
+        },
+      },
+      borderRadius: {
+        lg: 'var(--radius)',
+      },
+    },
+  },
+  plugins: [],
+}

--- a/next-app/tsconfig.json
+++ b/next-app/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add minimal Next.js project in `next-app`
- implement shadcn-like button component and custom theming
- document how to run the example

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68627f7017008331846783bf4ee561e8